### PR TITLE
feat: use package name from Cargo.toml in echo prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Nothing yet
 
+## [0.3.1] - 2025-06-08
+
+### Changed
+- Command echo prefix from "cmd" to "{package_name}:cmd" using `CARGO_PKG_NAME` for better tool identification
+- File system operation echo prefix from "fs" to "{package_name}:fs" using `CARGO_PKG_NAME` for better tool identification
+
 ## [0.3.0] - 2025-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scripty"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ansi-to-html",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "scripty"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.87.0"
 authors = ["Mozk Taberenai <mozktaberenai@gmail.com>"]

--- a/src/cmd/pipeline.rs
+++ b/src/cmd/pipeline.rs
@@ -947,7 +947,7 @@ impl Pipeline {
         let mut parts = Vec::new();
 
         // Add cmd prefix
-        parts.push(format!("{BRIGHT_BLACK}cmd{BRIGHT_BLACK:#}"));
+        parts.push(format!("{BRIGHT_BLACK}{}:cmd{BRIGHT_BLACK:#}", env!("CARGO_PKG_NAME")));
 
         for (i, (cmd, pipe_mode)) in self.connections.iter().enumerate() {
             if i > 0 {

--- a/src/cmd/pipeline.rs
+++ b/src/cmd/pipeline.rs
@@ -947,7 +947,10 @@ impl Pipeline {
         let mut parts = Vec::new();
 
         // Add cmd prefix
-        parts.push(format!("{BRIGHT_BLACK}{}:cmd{BRIGHT_BLACK:#}", env!("CARGO_PKG_NAME")));
+        parts.push(format!(
+            "{BRIGHT_BLACK}{}:cmd{BRIGHT_BLACK:#}",
+            env!("CARGO_PKG_NAME")
+        ));
 
         for (i, (cmd, pipe_mode)) in self.connections.iter().enumerate() {
             if i > 0 {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 fn echo_operation(op: &str, details: &str) {
     if should_echo() {
-        let styled_fs = format!("{BRIGHT_BLACK}fs{BRIGHT_BLACK:#}");
+        let styled_fs = format!("{BRIGHT_BLACK}{}:fs{BRIGHT_BLACK:#}", env!("CARGO_PKG_NAME"));
         let styled_op = format!("{BOLD_CYAN}{op}{BOLD_CYAN:#}");
         let styled_details = format!("{BOLD_UNDERLINE}{details}{BOLD_UNDERLINE:#}");
         conditional_eprintln(format_args!(

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,7 +12,10 @@ use std::path::Path;
 
 fn echo_operation(op: &str, details: &str) {
     if should_echo() {
-        let styled_fs = format!("{BRIGHT_BLACK}{}:fs{BRIGHT_BLACK:#}", env!("CARGO_PKG_NAME"));
+        let styled_fs = format!(
+            "{BRIGHT_BLACK}{}:fs{BRIGHT_BLACK:#}",
+            env!("CARGO_PKG_NAME")
+        );
         let styled_op = format!("{BOLD_CYAN}{op}{BOLD_CYAN:#}");
         let styled_details = format!("{BOLD_UNDERLINE}{details}{BOLD_UNDERLINE:#}");
         conditional_eprintln(format_args!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! scripty = "0.3.0"
+//! scripty = "0.3.1"
 //! ```
 //!
 //! ## Platform Support


### PR DESCRIPTION
## Changes

- Change cmd echo prefix from hardcoded 'cmd' to '{package_name}:cmd' using 
- Change fs echo prefix from hardcoded 'fs' to '{package_name}:fs' using 
- Update version from 0.3.0 to 0.3.1
- Add changelog entry for v0.3.1

## Benefits

- **Maintainability**: Eliminates hardcoded package names
- **Consistency**: Cargo.toml becomes the single source of truth for package name
- **Flexibility**: Package name changes automatically reflect in echo output

## Technical Details

Uses the  macro to dynamically retrieve the package name from Cargo.toml at compile time, with no runtime overhead.